### PR TITLE
broaden rich dependency specification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "Packet Coders", email = "contact@packetcoders.io" }]
 requires-python = "~=3.11"
 readme = "README.md"
 dependencies = [
-    "rich==14.0.0",
+    "rich>=12, <15",
     "nornir>=3.5.0,<4",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -582,7 +582,7 @@ wheels = [
 
 [[package]]
 name = "nornir-inspect"
-version = "1.0.3"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "nornir" },
@@ -657,7 +657,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "nornir", specifier = ">=3.5.0,<4" },
-    { name = "rich", specifier = "==14.0.0" },
+    { name = "rich", specifier = ">=12,<15" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Suggestion to broaden the supported rich dependency specification.

The current specification limits the dependency to a very specific version, which creates a limitation towards other libraries that may depend on Rich as well.

The tests seem to succeed when using Rich v12.5.1.

```
nornir-inspect % uv tree | grep Rich
Resolved 83 packages in 11ms
nornir-inspect % uv tree | grep rich
Resolved 83 packages in 1ms
├── rich v12.5.1
│   ├── rich v12.5.1 (*)
│   └── rich v12.5.1 (*)
nornir-inspect % uv run pytest tests -vv --tb=short -s
=================================================================================== test session starts ===================================================================================
platform darwin -- Python 3.12.2, pytest-8.4.0, pluggy-1.6.0 -- /Users/wim/dev/nornir-inspect/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/wim/dev/nornir-inspect
configfile: pyproject.toml
plugins: clarity-1.0.1
collected 23 items

tests/test_example.py::test_nornir_inspect_example PASSED
tests/test_nr_inspect.py::test_get_object_attributes PASSED
tests/test_nr_inspect.py::test_create_object_attribute_tree PASSED
tests/test_nr_inspect.py::test_create_object_attribute_tree_without_values_headings PASSED
tests/test_nr_inspect.py::test_create_object_attribute_tree_level_1[0-0-failed = False] PASSED
tests/test_nr_inspect.py::test_create_object_attribute_tree_level_1[1-0-failed_hosts = {}] PASSED
tests/test_nr_inspect.py::test_create_object_attribute_tree_level_1[2-0-name = task_1] PASSED
tests/test_nr_inspect.py::test_create_object_attribute_tree_level_1[3-4-<class 'nornir.core.task.MultiResult'> ['node1']] PASSED
tests/test_nr_inspect.py::test_create_object_attribute_tree_level_1[4-4-<class 'nornir.core.task.MultiResult'> ['node2']] PASSED
tests/test_nr_inspect.py::test_create_object_attribute_tree_level_1[5-4-<class 'nornir.core.task.MultiResult'> ['node3']] PASSED
tests/test_nr_inspect.py::test_create_object_attribute_tree_level_2[0-0-failed = False-3] PASSED
tests/test_nr_inspect.py::test_create_object_attribute_tree_level_2[0-0-failed = False-4] PASSED
tests/test_nr_inspect.py::test_create_object_attribute_tree_level_2[0-0-failed = False-5] PASSED
tests/test_nr_inspect.py::test_create_object_attribute_tree_level_2[1-0-failed_hosts = {}-3] PASSED
tests/test_nr_inspect.py::test_create_object_attribute_tree_level_2[1-0-failed_hosts = {}-4] PASSED
tests/test_nr_inspect.py::test_create_object_attribute_tree_level_2[1-0-failed_hosts = {}-5] PASSED
tests/test_nr_inspect.py::test_create_object_attribute_tree_level_2[2-0-name = task_1-3] PASSED
tests/test_nr_inspect.py::test_create_object_attribute_tree_level_2[2-0-name = task_1-4] PASSED
tests/test_nr_inspect.py::test_create_object_attribute_tree_level_2[2-0-name = task_1-5] PASSED
tests/test_nr_inspect.py::test_create_object_attribute_tree_level_2[3-10-<class 'nornir.core.task.Result'> [0]-3] PASSED
tests/test_nr_inspect.py::test_create_object_attribute_tree_level_2[3-10-<class 'nornir.core.task.Result'> [0]-4] PASSED
tests/test_nr_inspect.py::test_create_object_attribute_tree_level_2[3-10-<class 'nornir.core.task.Result'> [0]-5] PASSED
tests/test_nr_inspect.py::test_nornir_inspect_output PASSED

=================================================================================== 23 passed in 0.17s ====================================================================================
```

It could be that even older versions of Rich are supported, but I didn't validate that.